### PR TITLE
Test via minio

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,5 @@
+[style]
+based_on_style = pep8
+column_limit = 120
+coalesce_brackets = true
+align_closing_bracket_with_visual_indent = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
 - '3.6'
 - '3.7'
-install: pip install tox-travis flit
+install: pip install -U pip tox-travis flit
 script: tox
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
 - '3.6'
 - '3.7'
-install: pip install tox-travis
+install: pip install tox-travis flit
 script: tox
 matrix:
   fast_finish: true

--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -205,7 +205,7 @@ class S3Storage(BaseStorage):
         try:
             return self.s3.create_bucket(Bucket=self._bucket_name)
         except ClientError as e:
-            if e.response['Error']['Code'] == 'BucketAlreadyExists':
+            if e.response['Error']['Code'] in ['BucketAlreadyExists', 'BucketAlreadyOwnedByYou']:
                 return self.s3.Bucket(self._bucket_name)
             else:
                 raise e

--- a/nondjango/storages/storages.py
+++ b/nondjango/storages/storages.py
@@ -9,7 +9,6 @@ from io import BytesIO, StringIO
 from .utils import prepare_path, md5s3
 from .files import File
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -56,8 +55,7 @@ def safe_join(base, *paths):
     # the base path is /.
     base_path_len = len(base_path)
     if (not final_path.startswith(base_path) or final_path[base_path_len] != '/'):
-        raise ValueError('the joined path is located outside of the base path'
-                         ' component')
+        raise ValueError('the joined path is located outside of the base path component')
 
     return final_path if starts_on_root else final_path.lstrip('/')
 
@@ -237,7 +235,7 @@ class S3Storage(BaseStorage):
                 logger.warning('Bucket does not exist, list() returning empty.')
             else:
                 raise
-    
+
     def listdir(self, name):
         valid_name = self.get_valid_name(name)
         path = self._normalize_name(valid_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['flit']
+requires = ['flit >= 1.1']
 build-backend = "flit.buildapi"
 
 [tool.flit.metadata.requires-extra]
@@ -13,6 +13,7 @@ dist-name = "nondjango-storages"
 module = "nondjango"
 author = "Alan Justino da Silva"
 author-email = "alan.justino@yahoo.com.br"
+home-page = "https://github.com/alanjds/nondjango-storages/"
 requires = [
     'boto3',
 ]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import tempfile
+import uuid
 
 import pytest
 
@@ -40,7 +41,7 @@ MINIO_S3_SETTINGS = {
     (storages.TemporaryFilesystemStorage, {}),
     (storages.S3Storage, {
         'settings': MINIO_S3_SETTINGS,
-        'workdir': 's3://nondjango-storages-test/storage-test/'
+        'workdir': f's3://nondjango-storages-test/storage-test-{uuid.uuid4()}/'
     }),
 ])
 def test_file_read_write(storage_class, storage_params):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -26,9 +26,22 @@ def test_filesystem_storages_honor_workdir():
     assert filename in os.listdir(workdir), 'File is not on the storage workdir'
 
 
+# From: https://docs.minio.io/docs/aws-cli-with-minio.html
+MINIO_S3_SETTINGS = {
+    'AWS_ACCESS_KEY_ID': 'Q3AM3UQ867SPQQA43P2F',
+    'AWS_SECRET_ACCESS_KEY': 'zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG',
+    'AWS_S3_REGION_NAME': 'us-east-1',
+    'AWS_S3_ENDPOINT_URL': 'https://play.min.io:9000',
+    'AWS_S3_SIGNATURE_VERSION': 's3v4',
+}
+
+
 @pytest.mark.parametrize("storage_class, storage_params", [
     (storages.TemporaryFilesystemStorage, {}),
-    (storages.S3Storage, {'workdir': 's3://gn-ninja/storage-test/'}),
+    (storages.S3Storage, {
+        'settings': MINIO_S3_SETTINGS,
+        'workdir': 's3://nondjango-storages-test/storage-test/'
+    }),
 ])
 def test_file_read_write(storage_class, storage_params):
     payload = 'test payload'

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+isolated_build = True
 envlist =
     py35
     py36

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ basepython = python3
 [testenv]
 deps=
     flit
-    pytest
-    pytest-cov
-    .
 
 commands=
+    flit install --deps=develop
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ envlist =
 
 skipsdist=True
 
+[tox:.package]
+basepython = python3
+
 [testenv]
 deps=
     flit

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython = python3
 deps=
     flit
     pip >= 20
+    .[test]
 
 commands=
-    flit install --deps=develop
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-isolated_build = True
 envlist =
     py35
     py36

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,6 @@ skipsdist=True
 
 [testenv]
 deps=
+    flit
     .[test]
 commands=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ basepython = python3
 [testenv]
 deps=
     flit
+    "pip >= 20"
 
 commands=
     flit install --deps=develop

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ basepython = python3
 [testenv]
 deps=
     flit
-    "pip >= 20"
+    pip >= 20
 
 commands=
     flit install --deps=develop

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,9 @@ basepython = python3
 [testenv]
 deps=
     flit
-    .[test]
-commands=pytest
+    pytest
+    pytest-cov
+    .
+
+commands=
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython = python3
 deps=
     flit
     pip >= 20
-    .[test]
 
 commands=
+    flit install --deps=develop
     pytest


### PR DESCRIPTION
When we wrote this initially, Amazon S3 was used for tests. This have the caveat that PRs could steal the API keys. Then we secured by only running PRs manually and after manual review.

Now that I do not work on GetNinjas anymore, my keys got revoked and this package tests are broken.

The root problem is AWS not providing disposable test buckets for libraries, and I am not willing to pay AWS just to have this test passing. Nor to mock the interactions to S3 and let it break silently on service changes.

As Minio is a battle-tested S3 implementation and have free buckets for tests, the package tests will be running using it.